### PR TITLE
Fix on dark theme print

### DIFF
--- a/src/print.ts
+++ b/src/print.ts
@@ -152,7 +152,7 @@ async function print(type: string, uri?: Uri, outFolder?: string) {
         ${extensionStyles}
         ${getStyles(doc.uri, hasMath, includeVscodeStyles)}
     </head>
-    <body class="vscode-body${config.get<string>('print.theme') === 'light' ? ' vscode-light' : ''}">
+    <body class="vscode-body${config.get<string>('print.theme') === 'light' ? ' vscode-light' : config.get<string>('print.theme') === 'dark' ? ' vscode-dark' : ''}">
         ${body}
         ${hasMath ? '<script async src="https://cdn.jsdelivr.net/npm/katex-copytex@latest/dist/katex-copytex.min.js"></script>' : ''}
         ${extensionScripts}


### PR DESCRIPTION
Hi,

When the theme dark is selected on configuration, the code block don't showing the dark theme.
This commit fix it.